### PR TITLE
refactor Poster - url

### DIFF
--- a/components/TV/SeasonsBlock.tsx
+++ b/components/TV/SeasonsBlock.tsx
@@ -20,13 +20,7 @@ const SeasonsBlock = ({ seasons }: ISeasons) => {
           .slice(0)
           .reverse()
           .map((item: any) => (
-            <Poster
-              key={item.id}
-              imageSrc={item.poster_path}
-              name={`Season ${item.season_number}`}
-              type="Season"
-              id={item.id}
-            />
+            <Poster key={item.id} imageSrc={item.poster_path} name={`Season ${item.season_number}`} />
           ))}
       </div>
       {!showSeasons && seasons.length > 4 && (

--- a/components/common/poster/Poster.tsx
+++ b/components/common/poster/Poster.tsx
@@ -4,32 +4,16 @@ import Link from "next/link";
 export interface IPoster {
   imageSrc: string;
   name: string;
-  id?: string;
-  type?: "Movies" | "Series" | "Season";
+  url?: string;
 }
 
-const Poster = ({ imageSrc, name, id, type }: IPoster) => (
-  <Link href={`${type?.toLowerCase()}/${id}`}>
-    <a>
+const Poster = ({ imageSrc, name, url }: IPoster) => (
+  <Link href={url || "#"}>
+    <a className={url ? "" : "pointer-events-none"}>
       <Image src={`https://image.tmdb.org/t/p/w185${imageSrc}`} width="170px" height="240px" className="rounded" />
       <div className="text-xs max-w-[170px] px-1 truncate">{name}</div>
     </a>
   </Link>
-);
-
-export const BackgroundPoster = ({ imageSrc, name }: IPoster) => (
-  <div>
-    <div
-      className="h-[180px] w-[127px] bg-cover rounded-t-lg"
-      style={{
-        backgroundImage: `url(https://image.tmdb.org/t/p/w185${imageSrc})`,
-      }}
-    />
-
-    <div className="py-2 text-xs text-center rounded-b-lg bg-black/25">
-      <div className="max-w-[127px] px-1 truncate">{name}</div>
-    </div>
-  </div>
 );
 
 export default Poster;

--- a/components/content/ContentInfiniteScroll.tsx
+++ b/components/content/ContentInfiniteScroll.tsx
@@ -52,8 +52,7 @@ const ContentInfiniteScroll = ({ fetchContent, type }: IContentInfiniteScroll) =
               <Poster
                 imageSrc={`${content.poster_path}`}
                 name={content.title || content.name}
-                id={content.id}
-                type={type}
+                url={`${type.toLowerCase()}/${content.id}`}
                 key={content.id}
               />
             ))


### PR DESCRIPTION
- Verwijdert type & id, in plaats daarvan een prop met url, die url moet je bij het maken van de Poster component zelf bouwen zodat die linkt naar de correcte url die nodig is

example;
`${type.toLowerCase()}/${content.id}`
resulteert in `tv/503459`

dit maakt het mogelijk om ook complexere url's te maken zoals `series/50435/season/1/episode/4` etc

- verwijdert ook niet-gebruikte component BackgroundPoster
- veranderd Poster zodat als er geen url is, hij ook niet klikbaar is

closes #60 