### PR TITLE
Hotfix/188 database only adds one season

### DIFF
--- a/src/components/common/JustWatch.tsx
+++ b/src/components/common/JustWatch.tsx
@@ -15,7 +15,7 @@ interface JustWatchProps {
 const JustWatch = ({ justWatch, themeColor }: JustWatchProps) => {
   const session = useSession();
   const [modalOpen, setModalOpen] = useState(false);
-  const currentLocation = justWatch.results[session.data?.user?.profile?.region?.toUpperCase() ?? "GB"];
+  const currentLocation = justWatch.results[session.data?.user?.profile?.language.toUpperCase() ?? "GB"];
 
   const close = () => setModalOpen(false);
   const open = () => setModalOpen(true);

--- a/src/components/common/JustWatch.tsx
+++ b/src/components/common/JustWatch.tsx
@@ -15,7 +15,7 @@ interface JustWatchProps {
 const JustWatch = ({ justWatch, themeColor }: JustWatchProps) => {
   const session = useSession();
   const [modalOpen, setModalOpen] = useState(false);
-  const currentLocation = justWatch.results[session.data?.user?.profile?.region.toUpperCase() ?? "GB"];
+  const currentLocation = justWatch.results[session.data?.user?.profile?.region?.toUpperCase() ?? "GB"];
 
   const close = () => setModalOpen(false);
   const open = () => setModalOpen(true);

--- a/src/pages/tv/[tvID]/season/[seasonID]/index.tsx
+++ b/src/pages/tv/[tvID]/season/[seasonID]/index.tsx
@@ -13,10 +13,13 @@ const TVPage = () => {
     tvID: tvID as string,
   });
 
-  const { data, status, refetch } = trpc.season.seasonByID.useQuery({
-    tvID: tvID as string,
-    seasonID: Number(seasonID),
-  });
+  const { data, status, refetch } = trpc.season.seasonByID.useQuery(
+    {
+      tvID: tvID as string,
+      seasonID: Number(seasonID),
+    },
+    { enabled: router.isReady }
+  );
 
   const markAsWatched = trpc.episode.markEpisodeAsWatched.useMutation({
     onSuccess: () => {

--- a/src/server/trpc/router/episode.ts
+++ b/src/server/trpc/router/episode.ts
@@ -39,80 +39,71 @@ export const episodeRouter = router({
     .mutation(async ({ ctx, input }) => {
       const url = new URL(`tv/${input?.seriesId}`, process.env.NEXT_PUBLIC_TMDB_API);
       url.searchParams.append("api_key", process.env.NEXT_PUBLIC_TMDB_KEY || "");
+      if (ctx) url.searchParams.append("language", ctx.session?.user?.profile.language as string);
 
       const show = await fetch(url).then((res) => res.json());
 
       const seriesPoster = show.poster_path ? show.poster_path : "/noimage.png";
 
-      // Save series
+      const newSeriesCreateUpdate = {
+        id: show.id,
+        name: show.name,
+        poster: seriesPoster,
+        seasons: {
+          connectOrCreate: await Promise.all(
+            show.seasons.map(async (season: any) => {
+              const url = new URL(
+                `tv/${input?.seriesId}/season/${season.season_number}`,
+                process.env.NEXT_PUBLIC_TMDB_API
+              );
+              url.searchParams.append("api_key", process.env.NEXT_PUBLIC_TMDB_KEY || "");
+
+              const seasonWithEpisodes = await fetch(url).then((res) => res.json());
+
+              return {
+                where: { id: season.id },
+                create: {
+                  id: season.id,
+                  name: season.name,
+                  poster: season.poster_path ? season.poster_path : seriesPoster,
+                  season_number: season.season_number,
+                  episodes: {
+                    connectOrCreate: seasonWithEpisodes.episodes.map((e: TmdbEpisode) => {
+                      return {
+                        where: { id: e.id },
+                        create: {
+                          id: e.id,
+                          name: e.name,
+                          episode_number: e.episode_number,
+                          season_number: e.season_number,
+                        },
+                      };
+                    }),
+                  },
+                },
+              };
+            })
+          ),
+        },
+      };
+
       const newSeries = await ctx.prisma.series.upsert({
         where: { id: input.seriesId },
-        update: {
-          id: show.id,
-          name: show.name,
-          poster: seriesPoster,
-        },
-        create: {
-          id: show.id,
-          name: show.name,
-          poster: seriesPoster,
-        },
+        update: newSeriesCreateUpdate,
+        create: newSeriesCreateUpdate,
       });
 
-      // Episodes and seasons
-      if (newSeries) {
-        Promise.all(
-          show.seasons.map(async (season: any) => {
-            const url = new URL(
-              `tv/${input?.seriesId}/season/${season.season_number}`,
-              process.env.NEXT_PUBLIC_TMDB_API
-            );
-            url.searchParams.append("api_key", process.env.NEXT_PUBLIC_TMDB_KEY || "");
-
-            const seasonWithEpisodes = await fetch(url).then((res) => res.json());
-
-            // Save season with episodes
-            const newSeason = {
-              id: season.id,
-              name: season.name,
-              poster: season.poster_path,
-              season_number: season.season_number,
-              series_id: show.id,
-              episodes: {
-                connectOrCreate: seasonWithEpisodes.episodes.map((e: TmdbEpisode) => {
-                  return {
-                    where: { id: e.id },
-                    create: {
-                      id: e.id,
-                      name: e.name,
-                      episode_number: e.episode_number,
-                      season_number: e.season_number,
-                    },
-                  };
-                }),
-              },
-            };
-
-            const addSeason = await ctx.prisma.seasons.upsert({
-              where: { id: season.id },
-              update: newSeason,
-              create: newSeason,
-            });
-
-            return addSeason;
-          })
-        ).then(async () => {
-          // Save episode
-          return await ctx.prisma.episodesHistory.create({
-            data: {
-              datetime: new Date(),
-              user_id: ctx?.session?.user?.id as string,
-              series_id: input.seriesId,
-              season_number: input.seasonNumber,
-              episode_number: input.episodeNumber,
-            },
-          });
+      if (newSeries !== null) {
+        const result = await ctx.prisma.episodesHistory.create({
+          data: {
+            datetime: new Date(),
+            user_id: ctx?.session?.user?.id as string,
+            series_id: input.seriesId,
+            season_number: input.seasonNumber,
+            episode_number: input.episodeNumber,
+          },
         });
+        return result;
       }
     }),
 


### PR DESCRIPTION
Als er een serie wordt toegevoegd worden nu alle series toegevoegd ipv alleen de seizoen waar de aflevering in zit. Fixed ook dat je elke keer een error krijgt op seizoen pagina omdat de seizoen id niet is ingeladen (cuz router isn't ready) & de justwatch pagina met region/language (though that whole thing is probably still broke, but now the page doesn't crash)

closes #188 
also fixes #186
![image](https://user-images.githubusercontent.com/46132597/202776418-83b9b606-b0fb-4d74-b2e1-0dc626c5fda2.png)
